### PR TITLE
Update config.xml

### DIFF
--- a/GameData/KerbalJointReinforcement/Plugins/PluginData/KerbalJointReinforcement/config.xml
+++ b/GameData/KerbalJointReinforcement/Plugins/PluginData/KerbalJointReinforcement/config.xml
@@ -30,6 +30,9 @@
     <string name="exemptModuleType3">MuMechToggle</string>
     <string name="exemptModuleType4">ModuleKerbetrotterHitch</string>
     <string name="exemptModuleType5">KASModuleWinch</string>
+    <string name="exemptModuleType6">ModuleGrappleNode</string>
+    <string name="exemptModuleType7">ModuleDockRotate</string>
+    <string name="exemptModuleType8">ModuleNodeRotate</string>
 
     <string name="decouplerStiffeningExtensionType0">ModuleEngines</string>
     <string name="decouplerStiffeningExtensionType1">ModuleEnginesFX</string>


### PR DESCRIPTION
Added exemption for ModuleGrappleNode, ModuleDockRotate and ModuleNodeRotate, as found in https://forum.kerbalspaceprogram.com/index.php?/topic/170484-141-dockrotate-rotation-control-on-docking-ports-plus-noderotate-make-any-part-rotate/&do=findComment&comment=3305721